### PR TITLE
explicit docker image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:latest-gpu
+FROM tensorflow/tensorflow:2.11.1-gpu
 
 #ENV VIRTUAL_ENV=/opt/venv
 #RUN python -m venv $VIRTUAL_ENV


### PR DESCRIPTION
if using `FROM tensorflow/tensorflow:latest-gpu` it would fail later `pip install -r requirements.txt`
