### PR TITLE
Feat/python package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ models
 final_model
 wandb
 cert
+venv/
+nakdimon.egg*

--- a/examples/usage.py
+++ b/examples/usage.py
@@ -1,0 +1,9 @@
+# pip3 install git+https://github.com/thewh1teagle/nakdimon
+# wget https://github.com/elazarg/nakdimon/raw/master/models/Nakdimon.h5
+
+import nakdimon 
+import nakdimon.predict
+
+
+result = nakdimon.predict("Nakdimon.h5", "שלום עולם!")
+print(result)

--- a/examples/usage.py
+++ b/examples/usage.py
@@ -1,9 +1,7 @@
-# pip3 install git+https://github.com/thewh1teagle/nakdimon
+# pip install git+https://github.com/thewh1teagle/nakdimon@feat/python-package
 # wget https://github.com/elazarg/nakdimon/raw/master/models/Nakdimon.h5
 
-import nakdimon 
-import nakdimon.predict
-
+import nakdimon
 
 result = nakdimon.predict("Nakdimon.h5", "שלום עולם!")
 print(result)

--- a/nakdimon/__init__.py
+++ b/nakdimon/__init__.py
@@ -1,0 +1,3 @@
+from .predict import predict
+
+__all__ = ['predict']

--- a/nakdimon/dataset.py
+++ b/nakdimon/dataset.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import random
 import numpy as np
 
-import hebrew
-import utils
+from nakdimon import hebrew, utils
+
 
 
 class CharacterTable:

--- a/nakdimon/hebrew.py
+++ b/nakdimon/hebrew.py
@@ -6,7 +6,7 @@ from typing import NamedTuple, Iterator, Iterable, List, Tuple
 from functools import lru_cache
 import re
 
-import utils
+from nakdimon import utils
 
 
 # "rafe" denotes a letter to which it would have been valid to add a diacritic of some category

--- a/nakdimon/predict.py
+++ b/nakdimon/predict.py
@@ -3,9 +3,7 @@ from functools import lru_cache
 
 import tensorflow as tf
 
-import utils
-import dataset
-import hebrew
+from nakdimon import utils, dataset, hebrew
 
 
 if tf.config.set_visible_devices([], 'GPU'):

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='nakdimon',
+    version='0.1.0',
+    packages=find_packages(),
+    install_requires=[
+        "numpy==1.24.1",
+        "tensorflow==2.13.0",
+        "wandb==0.17.0"
+    ],
+)


### PR DESCRIPTION
Resolve https://github.com/elazarg/nakdimon/issues/22 and https://github.com/elazarg/nakdimon/issues/19

Now it's much simpler to use nakdimon in Python:

```python
# pip install git+https://github.com/thewh1teagle/nakdimon@feat/python-package
# wget https://github.com/elazarg/nakdimon/raw/master/models/Nakdimon.h5

import nakdimon 

result = nakdimon.predict("Nakdimon.h5", "שלום עולם!")
print(result)
```

It will be best if you could publish pypi package without the model file as it's very heavy.
Let me know if you willing to merge it, and I'll change the example pip command to point into that repo.

---
פְּרוֹיֶקְט מַדְהִים, תּוֹדָה!