### PR TITLE
Make TensorFlow optional

### DIFF
--- a/nakdimon/predict.py
+++ b/nakdimon/predict.py
@@ -1,21 +1,32 @@
 import logging
 import pathlib
 from functools import lru_cache
-
-import tensorflow as tf
+from typing import Any
 
 from nakdimon import utils, dataset, hebrew
 from nakdimon.config import MAIN_MODEL
 
-if tf.config.set_visible_devices([], 'GPU'):
-    logging.warning('No GPU available.')
+def _require_tensorflow():
+    try:
+        import tensorflow as tf  # type: ignore
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "TensorFlow is required for the built-in Nakdimon .h5 predictor. "
+            "Install it with `pip install 'nakdimon[tf]'`."
+        ) from exc
+
+    if tf.config.set_visible_devices([], 'GPU'):
+        logging.warning('No GPU available.')
+
+    return tf
 
 
 @lru_cache()
-def load_cached_model(m: pathlib.Path | str) -> tf.Module:
+def load_cached_model(m: pathlib.Path | str) -> Any:
     if isinstance(m, str):
         return load_cached_model(pathlib.Path(m))
     assert isinstance(m, pathlib.Path)
+    tf = _require_tensorflow()
     model = tf.keras.models.load_model(m, custom_objects={'loss': None})
     return model
 
@@ -35,7 +46,8 @@ def merge_unconditional(texts, tnss, nss, dss, sss):
     return res
 
 
-def predict(text: str, model_or_model_path: tf.Module | str = MAIN_MODEL, maxlen=10000) -> str:
+def predict(text: str, model_or_model_path: Any | str = MAIN_MODEL, maxlen=10000) -> str:
+    tf = _require_tensorflow()
     if isinstance(model_or_model_path, (pathlib.Path, str)):
         model_or_model_path = load_cached_model(model_or_model_path)
     if not isinstance(model_or_model_path, tf.Module):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,14 @@ classifiers = [
 ]
 dynamic = ["dependencies"]
 
+[project.optional-dependencies]
+tf = [
+    "keras==2.15.0",
+    "tensorflow==2.15.0",
+    "tensorflowjs==4.20.0",
+    "wandb==0.17.0",
+]
+
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,4 @@ numpy==1.26.2
 requests==2.32.4
 requests-oauthlib==1.3.1
 Flask==2.2.5
-keras==2.15.0
-tensorflowjs==4.20.0
-tensorflow==2.15.0
-wandb==0.17.0
 prettytable==3.6.0


### PR DESCRIPTION
## Summary

Make TensorFlow an optional dependency instead of installing it unconditionally.

## Motivation

`pip install nakdimon` currently fails on Python 3.12 because `tensorflow==2.15.0`
does not provide Python 3.12 wheels.

## Changes

- Move TensorFlow/Keras/TensorFlowJS/W&B dependencies to the `tf` extra.
- Lazily import TensorFlow only when the built-in `.h5` predictor is used.
- Keep the default package installable and importable without TensorFlow.

## Tested

On Python 3.12.3 / Linux:

- Before this change, `pip install -e .` fails because `tensorflow==2.15.0`
  cannot be resolved.
- After this change, `pip install -e .` succeeds.
- `import nakdimon.predict` succeeds without TensorFlow installed.