### PR TITLE
ci: auto-generate release notes + wheel-install smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,16 +103,18 @@ jobs:
           uv venv .wheel-env --python ${{ matrix.python-version }}
           if [ "$RUNNER_OS" = "Windows" ]; then
             VENV_BIN="$PWD/.wheel-env/Scripts"
+            VENV_PY="$VENV_BIN/python.exe"
           else
             VENV_BIN="$PWD/.wheel-env/bin"
+            VENV_PY="$VENV_BIN/python"
           fi
           # PATH-prepend for all subsequent steps so `nakdimon`, `diacritize`,
           # `python` resolve from the freshly installed wheel — and resolve
-          # without OS-specific `.exe` handling.
+          # without OS-specific `.exe` handling in subsequent steps.
           echo "$VENV_BIN" >> "$GITHUB_PATH"
           # `uv venv` doesn't seed pip; use uv's resolver to install the wheel
           # into that specific venv directly.
-          uv pip install --python "$VENV_BIN/python" dist/nakdimon-*.whl
+          uv pip install --python "$VENV_PY" dist/nakdimon-*.whl
       - name: CLI works from a directory without tests/ — version / help
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,8 +110,9 @@ jobs:
           # `python` resolve from the freshly installed wheel — and resolve
           # without OS-specific `.exe` handling.
           echo "$VENV_BIN" >> "$GITHUB_PATH"
-          "$VENV_BIN/python" -m pip install --upgrade pip
-          "$VENV_BIN/pip" install dist/nakdimon-*.whl
+          # `uv venv` doesn't seed pip; use uv's resolver to install the wheel
+          # into that specific venv directly.
+          uv pip install --python "$VENV_BIN/python" dist/nakdimon-*.whl
       - name: CLI works from a directory without tests/ — version / help
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,65 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - run: uvx ruff check nakdimon scripts tests
+
+  wheel-install:
+    # Builds the wheel and installs it into a clean venv on a clean working
+    # directory, then runs the CLI from there. Catches packaging-boundary
+    # bugs that source-tree tests miss — like the v0.2.0 regression where
+    # the CLI assumed `tests/` existed in the user's CWD.
+    name: wheel-install (${{ matrix.os }} / ${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.12", "3.13", "3.14"]
+        include:
+          - os: windows-latest
+            python-version: "3.13"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Build wheel
+        run: uv build --wheel
+      - name: Install wheel into fresh venv
+        shell: bash
+        run: |
+          uv venv .wheel-env --python ${{ matrix.python-version }}
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            VENV_BIN="$PWD/.wheel-env/Scripts"
+          else
+            VENV_BIN="$PWD/.wheel-env/bin"
+          fi
+          # PATH-prepend for all subsequent steps so `nakdimon`, `diacritize`,
+          # `python` resolve from the freshly installed wheel — and resolve
+          # without OS-specific `.exe` handling.
+          echo "$VENV_BIN" >> "$GITHUB_PATH"
+          "$VENV_BIN/python" -m pip install --upgrade pip
+          "$VENV_BIN/pip" install dist/nakdimon-*.whl
+      - name: CLI works from a directory without tests/ — version / help
+        shell: bash
+        run: |
+          mkdir -p empty_cwd
+          cd empty_cwd
+          nakdimon --version
+          nakdimon --help > /dev/null
+          nakdimon predict --help > /dev/null
+          nakdimon train --help > /dev/null
+          nakdimon run_test --help > /dev/null
+          nakdimon results --help > /dev/null
+      - name: Predict end-to-end from the installed wheel
+        shell: bash
+        run: |
+          cd empty_cwd
+          echo 'שלום עולם' > input.txt
+          diacritize input.txt -o=output.txt
+          cat output.txt
+          # Output must contain a niqqud mark in the U+05B0–U+05C7 range.
+          python -c "
+          text = open('output.txt', encoding='utf-8').read()
+          assert any(0x05B0 <= ord(c) <= 0x05C7 for c in text), f'no niqqud in {text!r}'
+          print('OK:', text.strip())
+          "

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,10 @@ jobs:
     # the CLI assumed `tests/` existed in the user's CWD.
     name: wheel-install (${{ matrix.os }} / ${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
+    env:
+      # PEP 540 UTF-8 mode — Windows Python's default cp1252 stdout encoding
+      # can't print Hebrew characters from this job's smoke tests.
+      PYTHONUTF8: "1"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -75,7 +75,8 @@ jobs:
           gh release create
           '${{ github.ref_name }}'
           --repo '${{ github.repository }}'
-          --notes ""
+          --title 'nakdimon ${{ github.ref_name }}'
+          --generate-notes
       - name: Upload artifact signatures to GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
Two CI improvements following the `v0.2.0` / `v0.2.1` release cycle.

### 1. Auto-generate release notes
`.github/workflows/python-publish.yml` previously did `gh release create … --notes ""`, which left every release with an empty title and empty body until I went back and `gh release edit`-ed them by hand. Switch to:

```yaml
gh release create '${{ github.ref_name }}'
    --title 'nakdimon ${{ github.ref_name }}'
    --generate-notes
```

`--generate-notes` builds a "What's Changed" section from the merged PR titles since the previous tag — same content GitHub shows in the new-release UI. After this lands, future tag pushes ship a release with a real title and a real changelog body without any manual step.

### 2. Wheel-install smoke job
The `v0.2.0` CLI crash slipped past CI because every existing test imports from the source tree, while the bug only showed up at the packaging boundary — an installed CLI run from a CWD without `tests/`. The new `wheel-install` job actually builds and installs the wheel:

```
uv build --wheel
uv venv .wheel-env --python <ver>
.wheel-env/.../pip install dist/nakdimon-*.whl
cd empty_cwd
nakdimon --version
nakdimon {predict,train,run_test,results} --help
echo 'שלום עולם' > input.txt
diacritize input.txt -o=output.txt   # asserts niqqud appears in output
```

**Matrix**: `ubuntu-latest` × `3.12 / 3.13 / 3.14` + `windows-latest` × `3.13`. The Windows row is the load-bearing one — the original bug only surfaced on Windows; Linux-only CI never would have caught it.

## Test plan
- [ ] `wheel-install (ubuntu-latest / 3.12)` green
- [ ] `wheel-install (ubuntu-latest / 3.13)` green
- [ ] `wheel-install (ubuntu-latest / 3.14)` green
- [ ] `wheel-install (windows-latest / 3.13)` green — proves the v0.2.1 fix actually works at the packaging boundary on the OS where the bug appeared
- [ ] Existing `test` and `lint` jobs still green